### PR TITLE
Use libqrencode-tools package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.23
 
-RUN apk add wireguard-tools libqrencode iptables
+RUN apk add wireguard-tools libqrencode-tools iptables
 
 COPY bin /usr/bin
 


### PR DESCRIPTION
## Summary
- replace the Alpine package name with libqrencode-tools so qrencode is installed

## Testing
- not run (package name change only)