### PR TITLE
Document client usage and honor WG_CONF_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ docker run --name wg \
            -d \
            --privileged \
            -p80:80/udp \
-           -r WG_PORT=80 \
+           -e WG_PORT=80 \
            -v test:/etc/wireguard \
            fopina/wireguard
 ```
@@ -20,6 +20,41 @@ docker exec -ti wg add_peer.sh peer1 10.253.3.2
 
 ```
 docker exec -ti wg show_peer.sh peer1
+```
+
+## client
+
+To use this image as a WireGuard client, provide an existing WireGuard
+configuration file. When `WG_CONF_FILE` already exists, the container skips the
+server configuration generation and runs `wg-quick up` with that file.
+
+For example, save your client configuration as `wg0.conf` and run:
+
+```
+docker run --name wg-client \
+           -d \
+           --privileged \
+           -v "$PWD/wg0.conf:/etc/wireguard/wg0.conf:ro" \
+           fopina/wireguard
+```
+
+The client configuration can include a `DNS = ...` line. The entrypoint prepares
+`resolvconf` before starting WireGuard so `wg-quick` can apply those DNS
+settings.
+
+Example client configuration:
+
+```
+[Interface]
+PrivateKey = <client private key>
+Address = 10.253.3.2/32
+DNS = 1.1.1.1, 1.0.0.1
+
+[Peer]
+PublicKey = <server public key>
+AllowedIPs = 0.0.0.0/0
+Endpoint = vpn.example.com:51900
+PersistentKeepalive = 25
 ```
 
 Available environment variables:

--- a/README.md
+++ b/README.md
@@ -24,23 +24,20 @@ docker exec -ti wg show_peer.sh peer1
 
 ## client
 
-To use this image as a WireGuard client, provide an existing WireGuard
-configuration file. When `WG_CONF_FILE` already exists, the container skips the
-server configuration generation and runs `wg-quick up` with that file.
+To use this image as a WireGuard client, mount an existing WireGuard
+configuration file and point `WG_CONF_FILE` at it. The container will skip server
+configuration generation and run `wg-quick up` with that file.
 
-For example, save your client configuration as `wg0.conf` and run:
+For example, save your client configuration as `client.conf` and run:
 
 ```
 docker run --name wg-client \
            -d \
            --privileged \
-           -v "$PWD/wg0.conf:/etc/wireguard/wg0.conf:ro" \
+           -e WG_CONF_FILE=/etc/wireguard/client.conf \
+           -v "$PWD/client.conf:/etc/wireguard/client.conf:ro" \
            fopina/wireguard
 ```
-
-The client configuration can include a `DNS = ...` line. The entrypoint prepares
-`resolvconf` before starting WireGuard so `wg-quick` can apply those DNS
-settings.
 
 Example client configuration:
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ docker run --name wg-client \
            fopina/wireguard
 ```
 
+There is also a Compose example that brings up the client and runs a one-shot
+`curl` container through the WireGuard network namespace. Save your client
+configuration as `examples/client.conf`, then run:
+
+```
+WG_CONF_FILE=/tmp/wg-client.conf docker compose -f examples/docker-compose.yml up --build --abort-on-container-exit --exit-code-from ip-check
+```
+
+Compose will stop the WireGuard client after `ip-check` exits, and the command
+will return the `ip-check` exit code. The Compose example uses `WG_CONF_FILE`
+for both the container environment and the mount target.
+
 Example client configuration:
 
 ```

--- a/bin/add_peer.sh
+++ b/bin/add_peer.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CONF_FILE="/etc/wireguard/wg0.conf"
+CONF_FILE="${WG_CONF_FILE:-/etc/wireguard/wg0.conf}"
 
 if [ -z "$2" ]; then
     echo "Usage: $0 peer_name peer_ip"

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -3,7 +3,7 @@
 if [ ! -e "${WG_CONF_FILE}" ]; then
     echo "${WG_CONF_FILE} not found, generating one"
     wg genkey | tee /etc/wireguard/server.key | wg pubkey > /etc/wireguard/server.pub
-    cat <<EOF > ${CONF_FILE}
+    cat <<EOF > ${WG_CONF_FILE}
 [Interface]
 Address = ${WG_SUBNET}.1/24
 SaveConfig = true
@@ -27,7 +27,9 @@ _term() {
 
 trap _term SIGTERM
 
-wg-quick up wg0
+# resolvconf -u || true
+
+wg-quick up ${WG_CONF_FILE}
 
 sleep infinity &
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -22,7 +22,7 @@ fi
 
 _term() {
   echo "Caught SIGTERM signal!"
-  wg-quick down wg0
+  wg-quick down ${WG_CONF_FILE}
 }
 
 trap _term SIGTERM

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -27,7 +27,9 @@ _term() {
 
 trap _term SIGTERM
 
-# resolvconf -u || true
+# let openresolv take control of resolv.conf - same as in https://github.com/linuxserver/docker-wireguard/blob/master/root/etc/s6-overlay/s6-rc.d/init-wireguard-confs/run
+resolvconf -a control 2>/dev/null < /etc/resolv.conf
+resolvconf -u
 
 wg-quick up ${WG_CONF_FILE}
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,20 @@
+name: docker-wireguard-example
+
+services:
+  wg-client:
+    build:
+      context: ..
+    image: docker-wireguard
+    container_name: wg-client
+    privileged: true
+    environment:
+      WG_CONF_FILE: ${WG_CONF_FILE}
+    volumes:
+      - ${WG_CONF_FILE}:${WG_CONF_FILE}:ro
+
+  ip-check:
+    image: alpine:3.23
+    depends_on:
+      - wg-client
+    network_mode: service:wg-client
+    command: sh -c "apk add --no-cache curl && curl ipinfo.io/ip"


### PR DESCRIPTION
## Summary
- document how to run the image as a WireGuard client with an existing config
- fix the quickstart environment variable flag
- honor WG_CONF_FILE in add_peer.sh so custom config paths stay consistent
- start wg-quick with WG_CONF_FILE and prepare resolvconf for DNS settings

## Verification
- docker build -t docker-wireguard-review .
- sh -n bin/entrypoint.sh
- sh -n bin/add_peer.sh
- sh -n bin/show_peer.sh